### PR TITLE
remove System76 Tech Docs from public list

### DIFF
--- a/mdbooks.yaml
+++ b/mdbooks.yaml
@@ -887,11 +887,6 @@
   folder: docs
   description: Crux is a framework for building cross-platform applications with better testability, higher code and behavior reuse, better safety, security, and more joy from better tools.
 
-- title: System76 Technical Documentation
-  site: https://tech-docs.system76.com/
-  repo: https://github.com/system76/tech-docs
-  description: System76 provides laptops, desktops, servers, and accessories. This book contains technical documentation for System76 hardware.
-
 - title: Tree-sitter
   repo: https://github.com/tree-sitter/tree-sitter
   folder: docs


### PR DESCRIPTION
This website has been migrated from mdBook to Astro/Starlight as of last month, due to some SEO concerns of our marketing team and tooling preferences of our web team (https://github.com/rust-lang/mdBook/pull/2706 was one concrete example of a feature we wanted now).

The mdBook version of the website is still in our git history and can be browsed as such: https://github.com/system76/tech-docs/tree/9eba0b8b0c6d388e1f23b836efdbce3f4b051e33 But I assume this list is meant to be websites *currently* using mdBook.